### PR TITLE
fix sed syntax

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1557,7 +1557,7 @@ applications:
 EOF
 
 replaceTag() {
-    sed -i '' "s|$1|$2|" siddhi-cd/values.yaml
+    sed -i "s|$1|$2|g" siddhi-cd/values.yaml
 }
 
 if [ "$1" != "" ]; then


### PR DESCRIPTION
I have found problem  in sed command syntax which leads to "No such file or directory" error.
Now, i fixed it 
